### PR TITLE
fix complaints about false rules and change name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "OLP-JSCS",
+  "name": "olp-javascript-style",
   "version": "0.0.1",
   "description": "Open Lighting Project jscs presets and rules",
   "main": "index.js",

--- a/presets/common.json
+++ b/presets/common.json
@@ -17,15 +17,13 @@
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
   "disallowSpacesInFunctionExpression": {
-    "beforeOpeningRoundBrace": true,
-    "beforeOpeningCurlyBrace": false
+    "beforeOpeningRoundBrace": true
   },
   "maximumLineLength": {
     "value": 80,
     "tabSize": 2,
     "allowComments": true,
-    "allowUrlComments": true,
-    "allowRegex": false
+    "allowUrlComments": true
   },
   "requireAnonymousFunctions": true,
   "requireBlocksOnNewline": true,
@@ -62,7 +60,6 @@
     "function"
   ],
   "requireSpacesInFunction": {
-    "beforeOpeningRoundBrace": false,
     "beforeOpeningCurlyBrace": true
   },
   "requireSpacesInForStatement": true,


### PR DESCRIPTION
It seems that jscs doesn't like things being false, also change the name of the package to olp-javascript-style
