### PR TITLE
disable requirePaddingNewLinesInObjects for the time being

### DIFF
--- a/presets/common.json
+++ b/presets/common.json
@@ -41,7 +41,7 @@
   ],
   "requireDotNotation": true,
   "requireSemicolons": true,
-  "requirePaddingNewLinesInObjects": true,
+  "requirePaddingNewLinesInObjects": false,
   "requireSpaceBeforeBinaryOperators": true,
   "requireSpaceAfterKeywords": [
     "do",


### PR DESCRIPTION
it's annoying for small objects and probably not necessary with the 80 characters per line limit 
